### PR TITLE
do text_search in text_tsim

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -126,8 +126,8 @@ class CatalogController < ApplicationController
     config.add_search_field('Alt',label: I18n.t('text_service.config.search.all_filters')) do |field|
       field.solr_parameters = {
           :fq => ['cat_ssi:work'],
-          :qf => 'author_name_tesim^5 work_title_tesim^5 text_tesim',
-          :pf => 'text_tesim'
+          :qf => 'author_name_tesim^5 work_title_tesim^5 text_tsim',
+          :pf => 'text_tsim'
       }
       field.solr_local_parameters = {
       }
@@ -177,8 +177,8 @@ class CatalogController < ApplicationController
       field.include_in_simple_select = false
       field.solr_parameters = {
           :fq => 'type_ssi:leaf',
-          :qf => 'text_tesim',
-          :pf => 'text_tesim',
+          :qf => 'text_tsim',
+          :pf => 'text_tsim',
           :hl => 'true',
       }
       field.solr_local_parameters = {

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -62,7 +62,7 @@ class SearchBuilder < Blacklight::SearchBuilder
     # this is not the optimal way of doing phrase search, but i have not find the right solr params
     if blacklight_params['match'] == 'phrase'
       solr_params['q'] = "\"#{solr_params['q']}\""
-      solr_params['qf'] = solr_params['qf'].gsub('text_tesim','text_tsim')
+      solr_params['qs'] = 0
     end
     if blacklight_params['match'] == 'all'
       solr_params[:mm] = '100%'


### PR DESCRIPTION
By changing the text search field from text_tesim to text_tsim we do get better search result for phrases with stopwords (eg. "som dig").
However we loose stemming which could be a problem. As another option we could be to create a solr-field that has stemming but no stopwords (and then reindex).

By setting query slop (qs) to 0 on phrase searches we only get exact phrase matches