### PR TITLE
passing high lighting info to backend

### DIFF
--- a/app/models/file_server.rb
+++ b/app/models/file_server.rb
@@ -12,6 +12,7 @@ class FileServer
     uri += "&op=#{opts[:op]}" if opts[:op].present?
     uri += "&prefix=#{opts[:prefix]}" if opts[:prefix].present?
     uri += "&q=#{URI.escape(opts[:q])}" if opts[:q].present?
+    uri += "&match=#{URI.escape(opts[:match])}" if opts[:match].present?
     uri += "&hostport=#{URI.escape(adl_hostport)}" 
 
     Rails.logger.debug("snippet url #{uri}")

--- a/app/views/catalog/_text.html.erb
+++ b/app/views/catalog/_text.html.erb
@@ -8,8 +8,9 @@
 <%# If not, the the q parameter will be left empty and the render_snippet will not highlight the text %>
 <% if ["Alt", "phrase"].include? search_field %>
     <% query_params = current_search_session.try(:query_params)
-       query = query_params[:q] if query_params.present?
-       query = query.gsub!(/^\"|\"?$/, '').strip if query.present?
+       query  = query_params[:q] if query_params.present?
+       qmatch = query_params['match'] if query_params.present?
+       query  = query.gsub!(/^\"|\"?$/, '').strip if query.present?
     %>
 <% end %>
 <div class="textToolbar">
@@ -83,7 +84,7 @@
   <% end %>
 
   <%= FileServer.render_snippet(@document['id'],
-                                {q: query, op: "render"}) %>
+                                {q: query, match: qmatch, op: "render"}) %>
 
   <script>
     var elems  = document.getElementsByClassName("exposableDocumentFunctions");


### PR DESCRIPTION
passing the argument of the type of match used when searching to the backend, notably the present.xq script, such that it can make a distinction between phrase and word match